### PR TITLE
R1/T3-model_banners_de_categorias_alteracoes-arthur_fernandes

### DIFF
--- a/lib/actions/banner_de_categoria_action.dart
+++ b/lib/actions/banner_de_categoria_action.dart
@@ -7,11 +7,15 @@ class AlterarBannerDeCategoria {
   AlterarBannerDeCategoria( this.listacategoria);
 
   BannerDeCategoriaModel bannerdecategoriaData = const BannerDeCategoriaModel(
-      [CategoriaBanner('Express'),
-        CategoriaBanner('Mercado'),
-        CategoriaBanner('Farmácia'),
-        CategoriaBanner('Bebidas'),
-        CategoriaBanner('Pizza'),
-        CategoriaBanner('Lanches') 
+      [  CategoriaBanner('Salgados','https://cdn.discordapp.com/attachments/814528592419094570/912145821808599060/salgados1.jpg'),
+         CategoriaBanner('Lanches','https://cdn.discordapp.com/attachments/814528592419094570/912145821292716062/lanches1.jpg'),
+         CategoriaBanner('Carnes','https://cdn.discordapp.com/attachments/814528592419094570/912145821049438238/carnes1.jpg'),
+         CategoriaBanner('Pizza','https://cdn.discordapp.com/attachments/814528592419094570/912145821565341736/pizza1.jpg'),
+         CategoriaBanner('Japonesa','https://cdn.discordapp.com/attachments/814528592419094570/912154611559858266/19C1-japonesa.png'),
+         CategoriaBanner('Açaí','https://cdn.discordapp.com/attachments/814528592419094570/912154798323793930/19C1-acai.png'), 
+         CategoriaBanner('Bebidas','https://cdn.discordapp.com/attachments/814528592419094570/912191740105089054/19C1-bebidas.png'),
+         CategoriaBanner('Saudável','https://cdn.discordapp.com/attachments/814528592419094570/912191814440742992/19C1-saudavel-v2.png'),
+         CategoriaBanner('Brasileira','https://cdn.discordapp.com/attachments/814528592419094570/912191878458380308/19C1-brasileira-v2.png'),
+         CategoriaBanner('Cozinha Rápida','https://cdn.discordapp.com/attachments/814528592419094570/912191949136605184/19C1-comida-rapida.png')
       ]);
 }

--- a/lib/app_state.dart
+++ b/lib/app_state.dart
@@ -24,12 +24,17 @@ class AppState {
 
       
       this.bannerdecategoriaData = const BannerDeCategoriaModel( 
-        [CategoriaBanner('express'),
-         CategoriaBanner('Mercado'),
-         CategoriaBanner('Farmácia'),
-         CategoriaBanner('Bebidas'),
-         CategoriaBanner('Pizza'),
-         CategoriaBanner('Lanches')]),
+        [CategoriaBanner('Salgados','https://cdn.discordapp.com/attachments/814528592419094570/912145821808599060/salgados1.jpg'),
+         CategoriaBanner('Lanches','https://cdn.discordapp.com/attachments/814528592419094570/912145821292716062/lanches1.jpg'),
+         CategoriaBanner('Carnes','https://cdn.discordapp.com/attachments/814528592419094570/912145821049438238/carnes1.jpg'),
+         CategoriaBanner('Pizza','https://cdn.discordapp.com/attachments/814528592419094570/912145821565341736/pizza1.jpg'),
+         CategoriaBanner('Japonesa','https://cdn.discordapp.com/attachments/814528592419094570/912154611559858266/19C1-japonesa.png'),
+         CategoriaBanner('Açaí','https://cdn.discordapp.com/attachments/814528592419094570/912154798323793930/19C1-acai.png'),
+         CategoriaBanner('Bebidas','https://cdn.discordapp.com/attachments/814528592419094570/912191740105089054/19C1-bebidas.png'),
+         CategoriaBanner('Saudável','https://cdn.discordapp.com/attachments/814528592419094570/912191814440742992/19C1-saudavel-v2.png'),
+         CategoriaBanner('Brasileira','https://cdn.discordapp.com/attachments/814528592419094570/912191878458380308/19C1-brasileira-v2.png'),
+         CategoriaBanner('Cozinha Rápida','https://cdn.discordapp.com/attachments/814528592419094570/912191949136605184/19C1-comida-rapida.png'),
+         ]),
 
         this.cardcategoriaData = const CategoriaModel([
 

--- a/lib/components/busca/banner_de_categoria_componente.dart
+++ b/lib/components/busca/banner_de_categoria_componente.dart
@@ -1,8 +1,6 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:ifood_engenharia_de_software/utilities/cores.dart';
 import 'package:ifood_engenharia_de_software/models/banner_de_categoria_model.dart';
-
 
 class BannersDeCategorias extends StatelessWidget {
   final List<CategoriaBanner> listacategoria;
@@ -12,30 +10,65 @@ class BannersDeCategorias extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final ButtonStyle style = ElevatedButton.styleFrom(
-        textStyle: const TextStyle(fontSize: 15, fontWeight: FontWeight.bold),
-        fixedSize: const Size(175, 70),
-        primary: AppCores.vermelhoPrincipal);
 
     return GridView.builder(
+        scrollDirection: Axis.vertical,
         gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
             crossAxisCount: 2,
             childAspectRatio: (4 / 2),
-            crossAxisSpacing: 20,
-            mainAxisSpacing: 20),
+            crossAxisSpacing: 10,
+            mainAxisSpacing: 10),
         shrinkWrap: true,
         itemCount: listacategoria.length,
         itemBuilder: (BuildContext context, index) {
-          return ElevatedButton(
-              style: style,
-              onPressed: () {},
-              child: Column(children: [
-                const SizedBox(height: 15),
-                Row( 
-                  children: [Text(listacategoria[index].nome),
-                  ]
+          return Container(
+            height: 100,
+            width: 400,
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(5),
+              color: Colors.grey[100],
+            image:  DecorationImage(
+              fit: BoxFit.fill,   
+              image: NetworkImage(listacategoria[index].imgurl)
+            ),
+          ),  
+
+            child:Padding(
+                padding: const EdgeInsets.all(5),
+                child:Text(listacategoria[index].nome,
+                  style: const TextStyle(fontSize: 15, fontWeight: FontWeight.bold, color: Colors.white),)
                 )
-              ]));
-        });
+          );
+        }
+    );
   }
 }
+
+              
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/lib/models/banner_de_categoria_model.dart
+++ b/lib/models/banner_de_categoria_model.dart
@@ -1,7 +1,7 @@
 class CategoriaBanner {
   final String nome;
-  
-  const CategoriaBanner(this.nome);
+  final String imgurl;
+  const CategoriaBanner(this.nome,this.imgurl);
 }
 
 class BannerDeCategoriaModel {

--- a/lib/pages/busca.dart
+++ b/lib/pages/busca.dart
@@ -17,11 +17,22 @@ class _PaginaBuscaState extends State<PaginaBusca>
     return Scaffold(
         body: Column(children: [
       const MecanismodeBusca(),
+      
+      const Align(
+        alignment: Alignment.topLeft,
+        child:Padding(
+         padding: EdgeInsets.only(left: 20,bottom:30),
+          child:Text(
+          'Categorias',
+          style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
+          )
+        )
+      ),
       AnimatedBuilder(
           animation: appStore,
           builder: (_, __) {
             return SizedBox(
-              width:340,
+              width:390,
               child:BannersDeCategorias(listacategoria: 
                 appStore.state.bannerdecategoriaData.listacategoria
               )  


### PR DESCRIPTION
Alterando o R1/T3-model_banners_de_categorias. O motivo da alteração é que o código anterior não incluia a passagem de imagens por parâmetro para a classe do componente. Após a alteração, essa necessidade foi atendida para dar procedimento a etapa de utilização das coleções do banco de dados. Agora o componente exibe normalmente as imagens correspondentes.